### PR TITLE
Allow UART devices to be listed as well when using otii_get_devices.

### DIFF
--- a/otii_tcp_client/otii.py
+++ b/otii_tcp_client/otii.py
@@ -77,7 +77,7 @@ class Otii:
             return []
         device_objects = []
         for device in response["data"]["devices"]:
-            if device["type"] == "Arc":
+            if device["type"] == "Arc" or device["type"] == "UART":
                 device_object = arc.Arc(device, self.connection)
                 device_objects.append(device_object)
         return device_objects


### PR DESCRIPTION
Fix for https://github.com/qoitech/otii-tcp-client-python/issues/6
Allows to return UART devices using the python tcp client for Otii automation toolbox.
Compatible with the specifications from https://www.qoitech.com/help/tcpserver/#otii_get_devices